### PR TITLE
Optimize tag and organization lookups with precomputed indexes

### DIFF
--- a/helm/src/helm/proxy/models.py
+++ b/helm/src/helm/proxy/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional
+from collections import defaultdict
 
 # Different modalities
 TEXT_MODEL_TAG: str = "text"
@@ -887,6 +888,15 @@ ALL_MODELS = [
 
 MODEL_NAME_TO_MODEL: Dict[str, Model] = {model.name: model for model in ALL_MODELS}
 
+# Precompute models by tag for faster lookup
+MODELS_BY_TAG = defaultdict(list)
+MODELS_BY_ORGANIZATION = defaultdict(list)
+
+for model in ALL_MODELS:
+    for tag in model.tags:
+        MODELS_BY_TAG[tag].append(model.name)
+    MODELS_BY_ORGANIZATION[model.organization].append(model.name)
+
 
 def get_model(model_name: str) -> Model:
     """Get the `Model` given the name."""
@@ -911,12 +921,12 @@ def get_models_by_organization(organization: str) -> List[str]:
     """
     Gets models by organization e.g., ai21 => ai21/j1-jumbo, ai21/j1-grande, ai21-large.
     """
-    return [model.name for model in ALL_MODELS if model.organization == organization]
+    return MODELS_BY_ORGANIZATION.get(organization, [])
 
 
 def get_model_names_with_tag(tag: str) -> List[str]:
     """Get all the name of the models with tag `tag`."""
-    return [model.name for model in ALL_MODELS if tag in model.tags]
+    return MODELS_BY_TAG.get(tag, [])
 
 
 def get_all_text_models() -> List[str]:


### PR DESCRIPTION
This PR improves the performance of `get_model_names_with_tag` and `get_models_by_organization` by precomputing dictionaries (`MODELS_BY_TAG` and `MODELS_BY_ORGANIZATION`). These dictionaries map tags and organizations to model names, enabling O(1) lookups.

### Changes:

- Precomputed `MODELS_BY_TAG` for faster tag-based lookups.
- Precomputed `MODELS_BY_ORGANIZATION` for faster organization-based lookups.
- Updated both methods to use these precomputed dictionaries.

### Benefits:

- Performance: Lookups are now O(1), significantly faster than the previous O(n) iteration over all models.
- Efficiency: Reduces repeated computation for frequent queries.

### Trade-offs:

- Slight increase in memory usage for storing the precomputed mappings.
- No changes in behavior, only performance improvements.
